### PR TITLE
fix: enable default features to bindgen for link libclang on osx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,7 @@ checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
 dependencies = [
  "glob",
  "libc",
+ "libloading",
 ]
 
 [[package]]

--- a/sonic-sys/Cargo.toml
+++ b/sonic-sys/Cargo.toml
@@ -11,9 +11,6 @@ repository = "https://github.com/mush42/sonic-sys"
 homepage = "https://github.com/mush42/sonic-sys"
 readme = "README.md"
 
-[build-dependencies.bindgen]
-version = "0.59.1"
-default-features = false
-
 [build-dependencies]
 cc = "1.0.79"
+bindgen = {version = "0.59.1", default-features = false, features = ["runtime"]}


### PR DESCRIPTION
Fixing linking issue on macOS when using with other bindgen crates such as `rodio`

```console
  --- stderr
  thread 'main' panicked at /Users/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clang-sys-1.7.0/src/lib.rs:1860:1:
  a `libclang` shared library is not loaded on this thread
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
warning: `sonata-piper` (lib) generated 1 warning
```

Fixed by enable default features of bindgen with sonic-sys